### PR TITLE
Clean wayland client listeners, and wrap them into wayland_client namespace

### DIFF
--- a/include/display/WaylandSurface.hpp
+++ b/include/display/WaylandSurface.hpp
@@ -22,7 +22,7 @@ namespace display
     struct wl_shell_surface *wlShellSurface{nullptr};
     struct wl_seat *wlSeat{nullptr};
 
-    SeatListener *seatListener;
+    wayland_client::SeatListener *seatListener;
 
   public:
     WaylandSurface(WaylandSurface const &) = delete;

--- a/include/listeners/KeyboardListener.hpp
+++ b/include/listeners/KeyboardListener.hpp
@@ -6,23 +6,26 @@
 #include <unistd.h>
 #include <iostream>
 
-class KeyboardListener
+namespace wayland_client
 {
-  struct xkb_context *xkbContext;
-  struct xkb_keymap *keymap{nullptr};
-  struct xkb_state *xkbState{nullptr};
+  class KeyboardListener
+  {
+    struct xkb_context *xkbContext;
+    struct xkb_keymap *keymap{nullptr};
+    struct xkb_state *xkbState{nullptr};
 
-  bool running = true;
+    bool running = true;
 
-  public:
-    KeyboardListener();
-    ~KeyboardListener() = default;
+    public:
+      KeyboardListener();
+      ~KeyboardListener() = default;
 
-    void keyboardKeymap(struct wl_keyboard *keyboard, uint32_t format, int32_t fd, uint32_t size);
-    void keyboardEnter(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys);
-    void keyboardLeave(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface);
-    void keyboardKey(struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
-    void keyboardModifiers(struct wl_keyboard *keyboard, uint32_t serial, uint32_t modsDepressed, uint32_t modsLatched, uint32_t modsLocked, uint32_t group);
+      void keyboardKeymap(struct wl_keyboard *keyboard, uint32_t format, int32_t fd, uint32_t size);
+      void keyboardEnter(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys);
+      void keyboardLeave(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface);
+      void keyboardKey(struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+      void keyboardModifiers(struct wl_keyboard *keyboard, uint32_t serial, uint32_t modsDepressed, uint32_t modsLatched, uint32_t modsLocked, uint32_t group);
 
-    bool getRunning() const;
-};
+      bool getRunning() const;
+  };
+}

--- a/include/listeners/PointerListener.hpp
+++ b/include/listeners/PointerListener.hpp
@@ -14,24 +14,27 @@ struct MouseButton {
   uint32_t state;
 };
 
-class PointerListener
+namespace wayland_client
 {
-  constexpr static uint32_t LEFT = 272;
-  constexpr static uint32_t RIGHT = 273;
+  class PointerListener
+  {
+    constexpr static uint32_t LEFT = 272;
+    constexpr static uint32_t RIGHT = 273;
 
-  PointerPosition pointerPosition;
-  MouseButton button;
+    PointerPosition pointerPosition;
+    MouseButton button;
 
-public:
-    PointerListener();
-    ~PointerListener() = default;
+  public:
+      PointerListener();
+      ~PointerListener() = default;
 
-    void pointerEnter(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t surfX, wl_fixed_t surfY);
-    void pointerLeave(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface);
-    void pointerMotion(struct wl_pointer *pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y);
-    void pointerButton(struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
-    void pointerAxis(struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value);
+      void pointerEnter(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t surfX, wl_fixed_t surfY);
+      void pointerLeave(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface);
+      void pointerMotion(struct wl_pointer *pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y);
+      void pointerButton(struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+      void pointerAxis(struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value);
 
-    PointerPosition getPositions();
-    MouseButton getButton();
-};
+      PointerPosition getPositions();
+      MouseButton getButton();
+  };
+}

--- a/include/listeners/SeatListener.hpp
+++ b/include/listeners/SeatListener.hpp
@@ -5,17 +5,20 @@
 #include "listeners/KeyboardListener.hpp"
 #include "listeners/PointerListener.hpp"
 
-class SeatListener {
+namespace wayland_client
+{
+  class SeatListener {
 
-  KeyboardListener *keyboardListener;
-  PointerListener *pointerListener;
+    KeyboardListener *keyboardListener;
+    PointerListener *pointerListener;
 
-  public:
-    SeatListener();
-    ~SeatListener() = default;
+    public:
+      SeatListener();
+      ~SeatListener() = default;
 
-    void seatCapabilities(struct wl_seat *seat, uint32_t capabilities);
-    void seatName(struct wl_seat *seat, const char *name);
+      void seatCapabilities(struct wl_seat *seat, uint32_t capabilities);
+      void seatName(struct wl_seat *seat, const char *name);
 
-    bool getRunning() const;
-};
+      bool getRunning() const;
+  };
+}

--- a/source/display/WaylandSurface.cpp
+++ b/source/display/WaylandSurface.cpp
@@ -14,7 +14,7 @@ namespace display
 	std::cerr << "error: " << err << std::endl;
 	throw std::runtime_error("Received error");
       }
-    seatListener = new SeatListener();
+    seatListener = new wayland_client::SeatListener();
     wl_display_roundtrip(wlDisplay);
     if (!wlCompositor)
     {

--- a/source/listeners/KeyboardListener.cpp
+++ b/source/listeners/KeyboardListener.cpp
@@ -1,67 +1,71 @@
 #include "listeners/KeyboardListener.hpp"
 
-KeyboardListener::KeyboardListener()
-  : xkbContext(xkb_context_new (XKB_CONTEXT_NO_FLAGS))
+namespace wayland_client
 {
 
-}
-
-void KeyboardListener::keyboardKeymap(struct wl_keyboard *keyboard, uint32_t format, int32_t fd, uint32_t size)
-{
-  char *keymapString = static_cast<char *>(mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0));
-
-  xkb_keymap_unref(keymap);
-  keymap = xkb_keymap_new_from_string(xkbContext, keymapString, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
-  munmap (keymapString, size);
-  close(fd);
-  xkb_state_unref(xkbState);
-  xkbState = xkb_state_new(keymap);
-//  std::cout << "KEYMAP: " << xkb_keymap_get_as_string(keymap,  XKB_KEYMAP_FORMAT_TEXT_V1) << std::endl;
-}
-
-void KeyboardListener::keyboardEnter(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys)
-{
-  std::cout << "Entering the window" << std::endl;
-}
-
-void KeyboardListener::keyboardLeave(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface)
-{
-  std::cout << "Leaving the window" << std::endl;
-}
-
-void KeyboardListener::keyboardKey(struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
-{
-  //Offset to get the correct ascii code in the table. The key map String start to 9, so you have to shift the code by 8
-  constexpr int offset = 8;
-
-  if (state == WL_KEYBOARD_KEY_STATE_PRESSED)
+  KeyboardListener::KeyboardListener()
+    : xkbContext(xkb_context_new (XKB_CONTEXT_NO_FLAGS))
   {
-    xkb_keysym_t keysym = xkb_state_key_get_one_sym(xkbState, key + offset);
-    uint32_t utf32 = xkb_keysym_to_utf32(keysym);
-    if (utf32) {
-      if (utf32 >= 0x21 && utf32 <= 0x7E) {
-        printf ("the key %c was pressed\n", (char)utf32);
-        if (utf32 == 'q')
-          running = false;
+
+  }
+
+  void KeyboardListener::keyboardKeymap(struct wl_keyboard *keyboard, uint32_t format, int32_t fd, uint32_t size)
+  {
+    char *keymapString = static_cast<char *>(mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0));
+
+    xkb_keymap_unref(keymap);
+    keymap = xkb_keymap_new_from_string(xkbContext, keymapString, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    munmap (keymapString, size);
+    close(fd);
+    xkb_state_unref(xkbState);
+    xkbState = xkb_state_new(keymap);
+  //  std::cout << "KEYMAP: " << xkb_keymap_get_as_string(keymap,  XKB_KEYMAP_FORMAT_TEXT_V1) << std::endl;
+  }
+
+  void KeyboardListener::keyboardEnter(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys)
+  {
+    std::cout << "Entering the window" << std::endl;
+  }
+
+  void KeyboardListener::keyboardLeave(struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface)
+  {
+    std::cout << "Leaving the window" << std::endl;
+  }
+
+  void KeyboardListener::keyboardKey(struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+  {
+    //Offset to get the correct ascii code in the table. The key map String start to 9, so you have to shift the code by 8
+    constexpr int offset = 8;
+
+    if (state == WL_KEYBOARD_KEY_STATE_PRESSED)
+    {
+      xkb_keysym_t keysym = xkb_state_key_get_one_sym(xkbState, key + offset);
+      uint32_t utf32 = xkb_keysym_to_utf32(keysym);
+      if (utf32) {
+        if (utf32 >= 0x21 && utf32 <= 0x7E) {
+          std::cout << "the key " << (char)utf32 << " was pressed" << std::endl;
+          if (utf32 == 'q')
+            running = false;
+        }
+        else {
+          printf ("the key U+%04X was pressed\n", utf32);
+        }
       }
       else {
-        printf ("the key U+%04X was pressed\n", utf32);
+        char name[64];
+        xkb_keysym_get_name(keysym, name, 64);
+        std::cout << "the key " << name << " was pressed" << std::endl;
       }
     }
-    else {
-      char name[64];
-      xkb_keysym_get_name(keysym, name, 64);
-      printf ("the key %s was pressed\n", name);
-    }
   }
-}
 
-void KeyboardListener::keyboardModifiers(struct wl_keyboard *keyboard, uint32_t serial, uint32_t modsDepressed, uint32_t modsLatched, uint32_t modsLocked, uint32_t group)
-{
-  xkb_state_update_mask(xkbState, modsDepressed, modsLatched, modsLocked, 0, 0, group);
-}
+  void KeyboardListener::keyboardModifiers(struct wl_keyboard *keyboard, uint32_t serial, uint32_t modsDepressed, uint32_t modsLatched, uint32_t modsLocked, uint32_t group)
+  {
+    xkb_state_update_mask(xkbState, modsDepressed, modsLatched, modsLocked, 0, 0, group);
+  }
 
-bool KeyboardListener::getRunning() const
-{
-  return running;
+  bool KeyboardListener::getRunning() const
+  {
+    return running;
+  }
 }

--- a/source/listeners/PointerListener.cpp
+++ b/source/listeners/PointerListener.cpp
@@ -1,47 +1,50 @@
 #include "listeners/PointerListener.hpp"
 
-PointerListener::PointerListener()
+namespace wayland_client
 {
-    pointerPosition = {0.0, 0.0};
-    button = {LEFT, 0};
-}
+  PointerListener::PointerListener()
+  {
+      pointerPosition = {0.0, 0.0};
+      button = {LEFT, 0};
+  }
 
-void PointerListener::pointerEnter(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t surfX, wl_fixed_t surfY)
-{
-  std::cout << "pointer enter" << std::endl;
-}
+  void PointerListener::pointerEnter(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t surfX, wl_fixed_t surfY)
+  {
+    std::cout << "pointer enter" << std::endl;
+  }
 
-void PointerListener::pointerLeave(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface)
-{
-  std::cout << "pointer leave" << std::endl;
-}
+  void PointerListener::pointerLeave(struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface)
+  {
+    std::cout << "pointer leave" << std::endl;
+  }
 
-void PointerListener::pointerMotion(struct wl_pointer *pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y)
-{
-  pointerPosition.x = wl_fixed_to_double(x);
-  pointerPosition.y = wl_fixed_to_double(y);
-}
+  void PointerListener::pointerMotion(struct wl_pointer *pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y)
+  {
+    pointerPosition.x = wl_fixed_to_double(x);
+    pointerPosition.y = wl_fixed_to_double(y);
+  }
 
-void PointerListener::pointerButton(struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
-{
-  this->button.button = button;
-  this->button.state = state;
+  void PointerListener::pointerButton(struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
+  {
+    this->button.button = button;
+    this->button.state = state;
 
-  std::cout << "pointer button (button " << button << ", state " << state << ")" <<
-  " at (x: " << pointerPosition.x << ", y: "  << pointerPosition.y << ")" << std::endl;
-}
+    std::cout << "pointer button (button " << button << ", state " << state << ")" <<
+    " at (x: " << pointerPosition.x << ", y: "  << pointerPosition.y << ")" << std::endl;
+  }
 
-void PointerListener::pointerAxis(struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value)
-{
-   std::cout << "pointer axis" << std::endl;
-}
+  void PointerListener::pointerAxis(struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value)
+  {
+     std::cout << "pointer axis" << std::endl;
+  }
 
-PointerPosition PointerListener::getPositions()
-{
-  return pointerPosition;
-}
+  PointerPosition PointerListener::getPositions()
+  {
+    return pointerPosition;
+  }
 
-MouseButton PointerListener::getButton()
-{
-  return button;
+  MouseButton PointerListener::getButton()
+  {
+    return button;
+  }
 }

--- a/source/listeners/SeatListener.cpp
+++ b/source/listeners/SeatListener.cpp
@@ -1,31 +1,34 @@
 #include "listeners/SeatListener.hpp"
 
-SeatListener::SeatListener()
+namespace wayland_client
 {
-  keyboardListener = new KeyboardListener();
-  pointerListener = new PointerListener();
-}
-
-void SeatListener::seatCapabilities(struct wl_seat *seat, uint32_t capabilities)
-{
-  if (capabilities & WL_SEAT_CAPABILITY_POINTER)
+  SeatListener::SeatListener()
   {
-    struct wl_pointer *pointer = wl_seat_get_pointer(seat);
-    addListener(pointer, *pointerListener);
+    keyboardListener = new KeyboardListener();
+    pointerListener = new PointerListener();
   }
-  if (capabilities & WL_SEAT_CAPABILITY_KEYBOARD)
+
+  void SeatListener::seatCapabilities(struct wl_seat *seat, uint32_t capabilities)
   {
-    struct wl_keyboard *keyboard = wl_seat_get_keyboard(seat);
-    addListener(keyboard, *keyboardListener);
+    if (capabilities & WL_SEAT_CAPABILITY_POINTER)
+    {
+      struct wl_pointer *pointer = wl_seat_get_pointer(seat);
+      addListener(pointer, *pointerListener);
+    }
+    if (capabilities & WL_SEAT_CAPABILITY_KEYBOARD)
+    {
+      struct wl_keyboard *keyboard = wl_seat_get_keyboard(seat);
+      addListener(keyboard, *keyboardListener);
+    }
   }
-}
 
-void SeatListener::seatName(struct wl_seat *seat, const char *name)
-{
+  void SeatListener::seatName(struct wl_seat *seat, const char *name)
+  {
 
-}
+  }
 
-bool SeatListener::getRunning() const
-{
-  return keyboardListener->getRunning();
+  bool SeatListener::getRunning() const
+  {
+    return keyboardListener->getRunning();
+  }
 }


### PR DESCRIPTION
Also replaces `printf` with `std::cout`

Closes #27 