### PR TITLE
Moved WindowTree into WaylandServerProtocol

### DIFF
--- a/include/protocol/WaylandServerProtocol.hpp
+++ b/include/protocol/WaylandServerProtocol.hpp
@@ -1,4 +1,5 @@
 #include <wayland-server.h>
+#include "display/WindowTree.hpp"
 
 namespace protocol
 {
@@ -8,9 +9,14 @@ namespace protocol
     struct wl_display *wlDisplay;
     struct wl_event_loop *wlEventLoop;
     struct wl_protocol_logger *wlProtocolLogger;
+    display::WindowTree windowTree;
 
   public:
     WaylandServerProtocol();
+    WaylandServerProtocol(WaylandServerProtocol const &) = delete;
+    WaylandServerProtocol(WaylandServerProtocol &&) = delete;
+    WaylandServerProtocol operator=(WaylandServerProtocol const &) = delete;
+    WaylandServerProtocol operator=(WaylandServerProtocol &&) = delete;
     ~WaylandServerProtocol();
 
     int32_t addSocket();
@@ -31,10 +37,7 @@ namespace protocol
     void eventDispatch(int32_t timeout);
     void process(struct wl_client *data);
 
-    WaylandServerProtocol(WaylandServerProtocol const &) = delete;
-    WaylandServerProtocol(WaylandServerProtocol &&) = delete;
-    WaylandServerProtocol operator=(WaylandServerProtocol const &) = delete;
-    WaylandServerProtocol operator=(WaylandServerProtocol &&) = delete;
+    display::WindowTree const &getWindowTree() const noexcept;
   };
 
 }

--- a/source/protocol/WaylandServerProtocol.cpp
+++ b/source/protocol/WaylandServerProtocol.cpp
@@ -24,7 +24,8 @@ namespace protocol
     : wl_listener(),
       wlDisplay(wl_display_create()),
       wlEventLoop(wl_display_get_event_loop(wlDisplay)),
-      wlProtocolLogger(nullptr)
+      wlProtocolLogger(nullptr),
+      windowTree(display::WindowData{{{{0, 0}}, {{1920, 1080}}}, true})
   {
     wl_global_create(wlDisplay, &wl_compositor_interface, 1, this,
 		     convertToWlGlobalBindFunc<&WaylandServerProtocol::bindCompositor>());
@@ -184,5 +185,10 @@ namespace protocol
     gid_t gid;
     wl_client_get_credentials(data, &pid, &uid, &gid);
     printf("Client with pid %d, uid %d, and gid %d connected\n", pid, uid, gid);
+  }
+
+  display::WindowTree const &WaylandServerProtocol::getWindowTree() const noexcept
+  {
+    return windowTree;
   }
 }


### PR DESCRIPTION
This will allow the server to perform some optimisation (such as double buffering the window tree).
Closes #38 