### PR TITLE
Fixed queue sharing validation warnings in renderer

### DIFF
--- a/source/display/Renderer.cpp
+++ b/source/display/Renderer.cpp
@@ -44,14 +44,12 @@ namespace display
 		    physicalDevice,
 		    {},
 		    vk::BufferUsageFlagBits::eTransferSrc,
-		    vk::MemoryPropertyFlagBits::eHostVisible,
-		    std::vector<uint32_t>{selectedQueueFamily})
+		    vk::MemoryPropertyFlagBits::eHostVisible)
     , vertexBuffer(device,
 		   physicalDevice,
 		   {},
 		   vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eIndexBuffer,
-		   vk::MemoryPropertyFlagBits::eHostVisible,
-		   std::vector<uint32_t>{selectedQueueFamily})
+		   vk::MemoryPropertyFlagBits::eHostVisible)
     , sampler(device.createSampler(vk::Filter::eNearest,
 				   vk::Filter::eNearest,
 				   vk::SamplerMipmapMode::eNearest,


### PR DESCRIPTION
It was caused by the fact that only one queue was specified in a case where no or multiple queues were expected.