### PR TITLE
Implement wl_surface role assignement and simple state functions

### DIFF
--- a/include/protocol/ShellSurface.hpp
+++ b/include/protocol/ShellSurface.hpp
@@ -16,6 +16,8 @@ namespace protocol
 
     ShellSurface(Surface *);
 
+    void commit();
+
     // wl interface functions
     void pong(struct wl_client *client,
 	      struct wl_resource *resource,

--- a/include/protocol/Surface.hpp
+++ b/include/protocol/Surface.hpp
@@ -1,23 +1,44 @@
 #pragma once
 
 #include <wayland-server.h>
+#include <variant>
 
 namespace protocol
 {
+  class ShellSurface;
+
   class Surface
   {
-    bool taken{false}; // surface already has a role
+    wl_output_transform transform{wl_output_transform::WL_OUTPUT_TRANSFORM_NORMAL};
+    struct wl_resource *buffer{nullptr};
+    int32_t scale{1};
+    class NoRole
+    {
+    public:
+      NoRole *operator->()
+      {
+	return this;
+      }
+
+      void commit();
+    };
+    std::variant<NoRole, ShellSurface *> role{NoRole{}};
   public:
     class Taken{};
 
-    void setTaken()
-    {
-      if (taken)
-	throw Taken{};
-      taken = true;
-    }
-      
+    Surface() = default;
+    Surface(Surface const &) = delete;
+    Surface(Surface &&) = delete;
 
+    template<class Role>
+    void setRole(Role *role)
+    {
+      if (!std::holds_alternative<NoRole>(this->role))
+	throw Taken{};
+      this->role = role;
+    }
+
+  public:
     // wl interface functions
     void destroy(struct wl_client *client,
 		 struct wl_resource *resource);

--- a/include/protocol/WaylandServerProtocol.hpp
+++ b/include/protocol/WaylandServerProtocol.hpp
@@ -10,8 +10,8 @@ namespace protocol
     struct wl_event_loop *wlEventLoop;
     struct wl_protocol_logger *wlProtocolLogger;
     display::WindowTree windowTree;
-
   public:
+    
     WaylandServerProtocol();
     WaylandServerProtocol(WaylandServerProtocol const &) = delete;
     WaylandServerProtocol(WaylandServerProtocol &&) = delete;

--- a/source/protocol/ShellSurface.cpp
+++ b/source/protocol/ShellSurface.cpp
@@ -1,3 +1,6 @@
+#include <cassert>
+#include <cstdio>
+
 #include "protocol/ShellSurface.hpp"
 #include "protocol/Surface.hpp"
 
@@ -5,7 +8,14 @@ namespace protocol
 {
   ShellSurface::ShellSurface(Surface *surface)
     : surface(surface)
-  {}
+  {
+    this->surface->setRole(this);
+  }
+
+  void ShellSurface::commit()
+  {
+    std::puts("commiting shell surface!");
+  }
 
   // wl interface functions
   void ShellSurface::pong([[maybe_unused]] struct wl_client *client,

--- a/source/protocol/Surface.cpp
+++ b/source/protocol/Surface.cpp
@@ -1,45 +1,72 @@
 #include "protocol/Surface.hpp"
+#include "protocol/ShellSurface.hpp"
+#include "display/WindowTree.hpp"
 
 namespace protocol
 {
   void Surface::destroy([[maybe_unused]] struct wl_client *client,
-			[[maybe_unused]] struct wl_resource *resource){}
+			[[maybe_unused]] struct wl_resource *resource)
+  {
+  }
 
   void Surface::attach([[maybe_unused]] struct wl_client *client,
 		       [[maybe_unused]] struct wl_resource *resource,
 		       [[maybe_unused]] struct wl_resource *buffer,
 		       [[maybe_unused]] int32_t x,
-		       [[maybe_unused]] int32_t y){}
+		       [[maybe_unused]] int32_t y)
+  {
+    this->buffer = buffer;
+  }
     
   void Surface::damage([[maybe_unused]] struct wl_client *client,
 		       [[maybe_unused]] struct wl_resource *resource,
 		       [[maybe_unused]] int32_t x,
 		       [[maybe_unused]] int32_t y,
 		       [[maybe_unused]] int32_t width,
-		       [[maybe_unused]] int32_t height){}
+		       [[maybe_unused]] int32_t height)
+  {
+  }
     
   void Surface::frame([[maybe_unused]] struct wl_client *client,
 		      [[maybe_unused]] struct wl_resource *resource,
-		      [[maybe_unused]] uint32_t callback){}
+		      [[maybe_unused]] uint32_t callback)
+  {
+  }
 
   void Surface::set_opaque_region([[maybe_unused]] struct wl_client *client,
 				  [[maybe_unused]] struct wl_resource *resource,
-				  [[maybe_unused]] struct wl_resource *region){}
+				  [[maybe_unused]] struct wl_resource *region)
+  {
+  }
 
   void Surface::set_input_region([[maybe_unused]] struct wl_client *client,
 				 [[maybe_unused]] struct wl_resource *resource,
-				 [[maybe_unused]] struct wl_resource *region){}
+				 [[maybe_unused]] struct wl_resource *region)
+  {
+  }
 
   void Surface::commit([[maybe_unused]] struct wl_client *client,
-		       [[maybe_unused]] struct wl_resource *resource){}
+		       [[maybe_unused]] struct wl_resource *resource)
+  {
+    std::visit([](auto role)
+	       {
+		 role->commit();
+	       }, role);
+  }
 
   void Surface::set_buffer_transform([[maybe_unused]] struct wl_client *client,
 				     [[maybe_unused]] struct wl_resource *resource,
-				     [[maybe_unused]] int32_t transform){}
+				     int32_t transform)
+  {
+    this->transform = wl_output_transform(transform);
+  }
 
   void Surface::set_buffer_scale([[maybe_unused]] struct wl_client *client,
 				 [[maybe_unused]] struct wl_resource *resource,
-				 [[maybe_unused]] int32_t scale){}
+				 int32_t scale)
+  {
+    this->scale = scale;
+  }
 
 
   void Surface::damage_buffer([[maybe_unused]] struct wl_client *client,
@@ -47,5 +74,11 @@ namespace protocol
 			      [[maybe_unused]] int32_t x,
 			      [[maybe_unused]] int32_t y,
 			      [[maybe_unused]] int32_t width,
-			      [[maybe_unused]] int32_t height){}
+			      [[maybe_unused]] int32_t height)
+  {
+  }
+
+  void Surface::NoRole::commit()
+  {
+  }
 }

--- a/source/protocol/WaylandServerProtocol.cpp
+++ b/source/protocol/WaylandServerProtocol.cpp
@@ -106,8 +106,6 @@ namespace protocol
 
     try
       {
-	surface->setTaken();
-
 	static auto shell_surface_implementation(createImplementation<struct wl_shell_surface_interface,
 						 &ShellSurface::pong,
 						 &ShellSurface::move,
@@ -129,7 +127,7 @@ namespace protocol
       }
     catch (Surface::Taken)
       {
-	printf("TODO: handle wayland error\n");
+	wl_resource_post_error(surfaceResource, WL_SHELL_ERROR_ROLE, "");
       }
   }
 


### PR DESCRIPTION
Add `setRole` template function to set a surface's role which is stored in a variant, to avoid vtables which do not mesh well with libWaylandServer.
Forwards `commit` to surface's assigned role.(Currently no-op if no role assigned)
Surface now stores:
- transform
- scale
- attached buffer
Attaching buffers isn't fully implemented: (x,y) are ignored.